### PR TITLE
ODP-1900: HBASE - ODP & CVE versions reconciliation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,7 +569,7 @@
          They ought to match the values found in our default hadoop profile, which is
          currently "hadoop-2.0". See HBASE-15925 for more info. -->
     <hadoop.version>${hadoop-two.version}</hadoop.version>
-    <hadoop.guava.version>32.0-jre</hadoop.guava.version>
+    <hadoop.guava.version>32.0.1-jre</hadoop.guava.version>
     <compat.module>hbase-hadoop2-compat</compat.module>
     <assembly.file>src/main/assembly/hadoop-two-compat.xml</assembly.file>
     <!--


### PR DESCRIPTION
### Pull Request Description: HBASE Compilation Without Test Cases (Branch ODP-3.3.6.0-1)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ea6febd4-961c-4389-9ad0-3eb7eabedce9">

#### Summary:
This pull request addresses the version reconciliation for the HBASE project, ensuring compatibility and resolving dependency issues by upgrading specified library versions.

#### Details:
The following versions were checked and updated as per the reconciliation process:

**Hadoop Version:** 3.3.6.3.3.6.0-1  
**Zookeeper Version:** 3.8.4.3.3.6.0-1 
**HBase Version:** 2.5.8.3.3.6.0-1

#### Updated Library Versions:
| CVE Library Name          | Mentioned Version in Sheet | Version Present          | Action Needed           |
|---------------------------|----------------------------|--------------------------|-------------------------|
| hadoop.guava.version            | 32.0.1-jre                        | 32.0-jre                  | Updated to 32.0.1-jre          |


#### Compilation:
The project compilation has been successfully completed and the build is stable.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d8649a13-b740-4e98-919c-59f47e596102">


#### Conclusion:
The HBASE codebase has been verified for the versions of various libraries as listed above. The necessary updates have been made to align the project with the specified versions. Compilation has been completed without test cases to ensure the required jars are created and cached locally. 

