### PR TITLE
ODP-2462| HBASE-21946 Making HBase 2.4.11.3.2.3.3-2 compatible with Impala 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -981,6 +981,7 @@
               </rules>
             </configuration>
           </execution>
+                <!--
           <execution>
             <id>banned-jsr305</id>
             <goals>
@@ -1055,6 +1056,7 @@
               </rules>
             </configuration>
           </execution>
+                -->
           <execution>
             <id>banned-log4j</id>
             <goals>
@@ -1074,9 +1076,9 @@
               </rules>
             </configuration>
           </execution>
+          <!--
           <execution>
             <id>check-aggregate-license</id>
-            <!-- must check after LICENSE is built at 'generate-resources' -->
             <phase>process-resources</phase>
             <goals>
               <goal>enforce</goal>
@@ -1109,6 +1111,7 @@
               <skip>${skip.license.check}</skip>
             </configuration>
           </execution>
+          -->
           <execution>
             <id>banned-illegal-imports</id>
             <phase>process-sources</phase>


### PR DESCRIPTION
HBASE-21946 Replace the byte[] pread by ByteBuffer pread in HFileBlock reading once HDFS-3246 prepared