### PR TITLE
ODP-6342 : Bump Netty version to 4.1.132.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,7 +580,7 @@
       modules and cause trouble if we only rely on transitive dependencies.
     -->
     <netty3.version>3.10.6.Final</netty3.version>
-    <netty4.version>4.1.119.Final</netty4.version>
+    <netty4.version>4.1.132.Final</netty4.version>
     <!-- end HBASE-15925 default hadoop compatibility values -->
     <audience-annotations.version>0.13.0</audience-annotations.version>
     <!--


### PR DESCRIPTION
This patch was tested locally.