### PR TITLE
OSV-22190|OSV-19098 -CVE - Upgrade to hbase-thirdparty 4.1.13 (#40)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
@@ -848,8 +848,14 @@ abstract class ServerRpcConnection implements Closeable {
     }
 
     @Override
+    public long readLong(int offset) {
+      return this.buf.getLong(offset);
+    }
+
+    @Override
     public int size() {
       return this.length;
     }
+
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -638,7 +638,7 @@
       Version of protobuf that hbase uses internally (we shade our pb) Must match what is out
       in hbase-thirdparty include.
     -->
-    <internal.protobuf.version>4.31.1</internal.protobuf.version>
+    <internal.protobuf.version>4.34.0</internal.protobuf.version>
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
     <thrift.path>thrift</thrift.path>
     <thrift.version>0.14.1</thrift.version>
@@ -699,7 +699,7 @@
         databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
         hbase-thirdparty.
     -->
-    <hbase-thirdparty.version>4.1.12</hbase-thirdparty.version>
+    <hbase-thirdparty.version>4.1.13</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>
@@ -1628,6 +1628,13 @@
         <groupId>com.sun.mail</groupId>
         <artifactId>jakarta.mail</artifactId>
         <version>1.6.8</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
* OSV-19098|OSV-12618: Bump up version to 4.1.130.Final (#26)

* HBASE-29509 Bump hbase-thirdparty to 4.1.12 (#7207)





* OSV-12618: Bump up version to 4.1.130.Final

---------





* OSV-19098 - CVE - Bump up netty version to 4.1.133.Final

* OSV-19098 - CVE - Bump up netty version to 4.1.133.Final - reverting revision

* OSV-19098 - CVE - Bump up hbase-thirdparty.version version to 4.1.13 to fix CVE-2025-59419

* OSV-19098|HBASE-29971 Upgrade to hbase-thirdparty 4.1.13 (#7904)






* OSV-19098 - CVE - Bump up hbase-thirdparty.version version to 4.1.13 to fix CVE-2025-59419

---------