### PR TITLE
OSV-22212: Bump opentelemetry.version 1.49.0 -> 1.62.0 (CVE-2026-45292 / opentelemetry-api)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -625,7 +625,7 @@
     <jruby.version>9.4.8.0</jruby.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <opentelemetry.version>1.49.0</opentelemetry.version>
+    <opentelemetry.version>1.62.0</opentelemetry.version>
     <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
     <opentelemetry-javaagent.version>2.15.0</opentelemetry-javaagent.version>
     <log4j2.version>2.25.3</log4j2.version>


### PR DESCRIPTION
## Summary
- Bump `opentelemetry.version` / OpenTelemetry BOM **1.49.0 → 1.62.0** in `pom.xml` (fixes `opentelemetry-api`).
- Addresses **CVE-2026-45292**.

## Why HBase (for OSV-22212 / Hadoop)
- Hadoop source does not pin OpenTelemetry.
- YARN TimelineService HBase modules depend on `hbase-client` / `hbase-common`, which ship `opentelemetry-api` into `hadoop-yarn/lib`.

## Tickets
- OSV-21687 (sehajsandhu/hbase)
- OSV-22212 (sehajsandhu/hadoop — transitive via yarn timelineservice-hbase)
