### PR TITLE
OSV-21633: Bump netty to 4.1.135.Final (netty 4.1.1* CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -593,7 +593,7 @@
       in the dependencyManagement section as it could still lead to different versions of netty
       modules and cause trouble if we only rely on transitive dependencies.
     -->
-    <netty4.version>4.1.132.Final</netty4.version>
+    <netty4.version>4.1.135.Final</netty4.version>
     <!-- end HBASE-15925 default hadoop compatibility values -->
     <audience-annotations.version>0.13.0</audience-annotations.version>
     <!--


### PR DESCRIPTION
## Summary
- Bump Netty to **4.1.135.Final** to address CVEs reported against netty **4.1.1\*.Final**.

## Tickets (12)
OSV-21633, OSV-21634, OSV-21635, OSV-21636, OSV-21637, OSV-21638, OSV-21642, OSV-21662, OSV-21665, OSV-21666, OSV-21670, OSV-21686
