### PR TITLE
OSV-21648 - CVE - Bumped-up Log4j to 2.25.4 to address CVE-2026-34478

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -628,7 +628,7 @@
     <opentelemetry.version>1.62.0</opentelemetry.version>
     <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
     <opentelemetry-javaagent.version>2.26.1</opentelemetry-javaagent.version>
-    <log4j2.version>2.25.3</log4j2.version>
+    <log4j2.version>2.25.4</log4j2.version>
     <mockito.version>4.11.0</mockito.version>
     <!--Internally we use a different version of protobuf. See hbase-protocol-shaded-->
     <external.protobuf.groupid>com.google.protobuf</external.protobuf.groupid>


### PR DESCRIPTION
- Library : Log4j
- Version : -> 2.25.4
- Tickets : OSV-21648, OSV-21649, OSV-21650, OSV-21651, OSV-21652, OSV-21664