### PR TITLE
OSV-21646 - CVE - Bumped-up jakarta.mail to 1.6.8 to address CVE-2025-7962

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1623,7 +1623,13 @@
         <artifactId>okio</artifactId>
         <version>3.4.0</version>
       </dependency>
-    </dependencies>
+    
+      <dependency>
+        <groupId>com.sun.mail</groupId>
+        <artifactId>jakarta.mail</artifactId>
+        <version>1.6.8</version>
+      </dependency>
+</dependencies>
   </dependencyManagement>
   <dependencies>
     <!--REMOVE THIS. HERE TEMPORARILY.


### PR DESCRIPTION
- Library : jakarta.mail
- Version : -> 1.6.8
- Tickets : OSV-21646