### PR TITLE
OSV-21668 - CVE - Bumped-up opentelemetry-javaagent to 2.26.1 to address CVE-2026-33701

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -627,7 +627,7 @@
     <hamcrest.version>1.3</hamcrest.version>
     <opentelemetry.version>1.49.0</opentelemetry.version>
     <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
-    <opentelemetry-javaagent.version>2.15.0</opentelemetry-javaagent.version>
+    <opentelemetry-javaagent.version>2.26.1</opentelemetry-javaagent.version>
     <log4j2.version>2.25.3</log4j2.version>
     <mockito.version>4.11.0</mockito.version>
     <!--Internally we use a different version of protobuf. See hbase-protocol-shaded-->


### PR DESCRIPTION
- Library : opentelemetry-javaagent
- Version : -> 2.26.1
- Tickets : OSV-21668